### PR TITLE
Fix type data for port in connect method

### DIFF
--- a/src/Module/Aerospike.php
+++ b/src/Module/Aerospike.php
@@ -296,7 +296,7 @@ class Aerospike extends CodeceptionModule
             return;
         }
 
-        $config = ['hosts' => [['addr' => $this->config['addr'], 'port' => $this->config['port']]], 'shm' => []];
+        $config = ['hosts' => [['addr' => $this->config['addr'], 'port' => (int)$this->config['port']]], 'shm' => []];
 
         $this->aerospike = new \Aerospike(
             $config,


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: -

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
For connect to aerospike db value `port` must be an integer. Else it throw exception `port must be a number`.


Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
